### PR TITLE
README.md installation example does not correctly parse browser_download_url.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please read [Apple](https://support.apple.com/en-us/HT208544)'s external GPU doc
 ## Installation
 **purge-wrangler.sh** auto-manages itself and provides multiple installation and recovery options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -s "https://api.github.com/repos/mayankk2308/purge-wrangler/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-wrangler.sh && chmod +x purge-wrangler.sh && ./purge-wrangler.sh && rm purge-wrangler.sh
+curl -s "https://api.github.com/repos/mayankk2308/purge-wrangler/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-wrangler.sh && chmod +x purge-wrangler.sh && ./purge-wrangler.sh && rm purge-wrangler.sh
 ```
 
 For future use, only the following will be required:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please read [Apple](https://support.apple.com/en-us/HT208544)'s external GPU doc
 ## Installation
 **purge-wrangler.sh** auto-manages itself and provides multiple installation and recovery options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -s "https://api.github.com/repos/mayankk2308/purge-wrangler/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":[ \t]*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-wrangler.sh && chmod +x purge-wrangler.sh && ./purge-wrangler.sh && rm purge-wrangler.sh
+curl -q -s "https://api.github.com/repos/mayankk2308/purge-wrangler/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":[ \t]*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-wrangler.sh && chmod +x purge-wrangler.sh && ./purge-wrangler.sh && rm purge-wrangler.sh
 ```
 
 For future use, only the following will be required:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please read [Apple](https://support.apple.com/en-us/HT208544)'s external GPU doc
 ## Installation
 **purge-wrangler.sh** auto-manages itself and provides multiple installation and recovery options. Once the **pre-requisites** are satisfied, install the script by running the following in **Terminal**:
 ```bash
-curl -s "https://api.github.com/repos/mayankk2308/purge-wrangler/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-wrangler.sh && chmod +x purge-wrangler.sh && ./purge-wrangler.sh && rm purge-wrangler.sh
+curl -s "https://api.github.com/repos/mayankk2308/purge-wrangler/releases/latest" | grep '"browser_download_url":' | sed -E 's/.*"browser_download_url":[ \t]*"([^"]+)".*/\1/' | xargs curl -L -s -0 > purge-wrangler.sh && chmod +x purge-wrangler.sh && ./purge-wrangler.sh && rm purge-wrangler.sh
 ```
 
 For future use, only the following will be required:


### PR DESCRIPTION
# Pull Request

### Problem(s)
The contents of the ~/.curlrc file may specify a user-agent which causes the server to return a single-line JSON response, as opposed to a multi-line response.

Specifically, specifying the following user-agent will exhibit the problem (single-line response):

```
# Disguise as IE 9 on Windows 7.
user-agent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
```

### Changes
Fix up the regex for finding browser_download_url to handle both multiline and single-line responses from the server.

### Context
This is only pertinent for users installing via the "latest" script method.  Users downloading the purge-wrapper script another way should not be affected.
